### PR TITLE
Retry all BadStatusLine exceptions

### DIFF
--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -341,10 +341,7 @@ class Session(object):
                 # line saying, "Presumably, the server closed the connection
                 # before sending a valid response."
                 # Raise as ECONNRESET to simplify retry logic.
-                if e.line == '' or e.line == "''":
-                    raise socket.error(errno.ECONNRESET)
-                else:
-                    raise
+                raise socket.error(errno.ECONNRESET)
 
         resp = _try_request_with_retries(iter(self.retry_delays))
         status = resp.status


### PR DESCRIPTION
https://jira.prozorro.org/browse/CS-5863

We want also catch the exception with line == "No status line received - the server has closed the connection"

from httplib

>  if not line:
            # Presumably, the server closed the connection before
            # sending a valid response.
            raise BadStatusLine("No status line received - the server has closed the connection")

> class BadStatusLine(HTTPException):
    def __init__(self, line):
        if not line:
            line = repr(line)
        self.args = line,
        self.line = line